### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,8 +7,8 @@
 #######################################
 
 ColorConverter	KEYWORD1
-RGBColor  KEYWORD1
-HSIColor  KEYWORD1
+RGBColor	KEYWORD1
+HSIColor	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -17,7 +17,7 @@ HSIColor  KEYWORD1
 HSItoRGB	KEYWORD2
 HSItoRGBW	KEYWORD2
 RGBtoHSI	KEYWORD2
-RGBWtoHSI KEYWORD2
+RGBWtoHSI	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords