### PR TITLE
Create a global ColorConverter instance inside the library

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,27 +6,12 @@ With HSI values, the overall power output of the LED remains constant, and the b
 
 = Commands =
 
-== ColorConverter
-
-.Syntax
-----
-ColorConverter converter;
-----
-
-.Parameters
-none
-
-.Returns
-void
-
-.Notes
-Creates a new instance of the library.
 
 == HSItoRGB
 
 .Syntax
 ----
-converter.HSItoRGB(hue, saturation, intensity);
+ColorConverter.HSItoRGB(hue, saturation, intensity);
 ----
 
 .Parameters
@@ -39,7 +24,7 @@ RGBColor (_struct_) - a structure containing four ints: red, green, blue, and wh
 
 .Example
 ----
-RGBColor c = converter.HSItoRGB(hue, saturation, intensity);
+RGBColor c = ColorConverter.HSItoRGB(hue, saturation, intensity);
 Serial.print(c.red);
 Serial.print(" ");
 Serial.print(c.green);
@@ -51,7 +36,7 @@ Serial.println(c.blue);
 
 .Syntax
 ----
-converter.HSItoRGB(hue, saturation, intensity);
+ColorConverter.HSItoRGB(hue, saturation, intensity);
 ----
 
 .Parameters
@@ -64,7 +49,7 @@ RGBColor (_struct_) - a structure containing four ints: red, green, blue, and wh
 
 .Example
 ----
-RGBColor c = converter.HSItoRGB(hue, saturation, intensity);
+RGBColor c = ColorConverter.HSItoRGB(hue, saturation, intensity);
 Serial.print(c.red);
 Serial.print(" ");
 Serial.print(c.green);
@@ -78,7 +63,7 @@ Serial.print(c.white);
 
 .Syntax
 ----
-converter.RGBtoHSI(red, green,  blue);
+ColorConverter.RGBtoHSI(red, green,  blue);
 ----
 
 .Parameters
@@ -91,7 +76,7 @@ HSIColor (_struct_) - a structure containing three floats: hue, saturation, and 
 
 .Example
 ----
-HSIColor c = converter.RGBtoHSI(red, green, blue);
+HSIColor c = ColorConverter.RGBtoHSI(red, green, blue);
 Serial.print(c.hue);
 Serial.print(" ");
 Serial.print(c.saturation);

--- a/examples/SerialToColorConverter/SerialToColorConverter.ino
+++ b/examples/SerialToColorConverter/SerialToColorConverter.ino
@@ -22,7 +22,6 @@
 
 #include <ColorConverter.h>
 
-ColorConverter converter;
 void setup() {
   Serial.begin(9600);       // initialize serial communication
   while (!Serial);          // wait until serial monitor is opened
@@ -38,7 +37,7 @@ void loop() {
       float s = Serial.parseInt();
       float i = Serial.parseInt();
       // do the conversion:
-      RGBColor color = converter.HSItoRGB(h, s, i);
+      RGBColor color = ColorConverter.HSItoRGB(h, s, i);
       // print the results:
       Serial.print(color.red);
       Serial.print(" ");
@@ -52,7 +51,7 @@ void loop() {
       float s = Serial.parseInt();
       float i = Serial.parseInt();
       // do the conversion:
-      RGBColor color = converter.HSItoRGBW(h, s, i);
+      RGBColor color = ColorConverter.HSItoRGBW(h, s, i);
       // print the results:
       Serial.print(color.red);
       Serial.print(" ");
@@ -67,7 +66,7 @@ void loop() {
       float g = Serial.parseInt();
       float b = Serial.parseInt();
       // do the conversion:
-      HSIColor color = converter.RGBtoHSI(r, g, b);
+      HSIColor color = ColorConverter.RGBtoHSI(r, g, b);
       // print the results:
       Serial.print(color.hue);
       Serial.print(" ");

--- a/src/ColorConverter.cpp
+++ b/src/ColorConverter.cpp
@@ -11,11 +11,11 @@
 
 */
 
-ColorConverter::ColorConverter() {
+ColorConverterClass::ColorConverterClass() {
   // empty initializer
 }
 
-struct RGBColor ColorConverter::HSItoRGBW(float hue, float saturation, float intensity) {
+struct RGBColor ColorConverterClass::HSItoRGBW(float hue, float saturation, float intensity) {
   struct RGBColor result = {0,0,0,0};        // the RGBW result you'll return
   hue = constrain(hue, 0, 360);              // constrain hue to 0-360
   hue = hue * PI / 180;                      // Convert to radians.
@@ -48,7 +48,7 @@ struct RGBColor ColorConverter::HSItoRGBW(float hue, float saturation, float int
 }
 
 
-struct RGBColor ColorConverter::HSItoRGB(float hue, float saturation, float intensity) {
+struct RGBColor ColorConverterClass::HSItoRGB(float hue, float saturation, float intensity) {
   struct RGBColor result = {0,0,0,0};        // the RGB result you'll return
   hue = constrain(hue, 0, 360);              // constrain hue to 0-360
   hue = hue * PI / 180;                      // Convert to radians.
@@ -81,7 +81,7 @@ struct RGBColor ColorConverter::HSItoRGB(float hue, float saturation, float inte
 }
 
 
-struct HSIColor ColorConverter::RGBtoHSI (int red, int green, int blue) {
+struct HSIColor ColorConverterClass::RGBtoHSI (int red, int green, int blue) {
   struct HSIColor result = {0,0,0};
   // floats for calculating saturation and intensity:
   float sat = 0;
@@ -121,3 +121,5 @@ struct HSIColor ColorConverter::RGBtoHSI (int red, int green, int blue) {
 
   return result;
 }
+
+ColorConverterClass ColorConverter;

--- a/src/ColorConverter.h
+++ b/src/ColorConverter.h
@@ -17,10 +17,10 @@ struct HSIColor {
   float intensity;
 };
 
-class ColorConverter
+class ColorConverterClass
 {
   public:
-    ColorConverter();
+    ColorConverterClass();
     struct RGBColor HSItoRGB(float hue, float saturation, float intensity);
     struct RGBColor HSItoRGBW(float hue, float saturation, float intensity);
     struct HSIColor RGBtoHSI (int red, int green, int blue);
@@ -29,5 +29,7 @@ class ColorConverter
   private:
 
 };
+
+extern ColorConverterClass ColorConverter;
 
 #endif


### PR DESCRIPTION
**WARNING: This is a breaking change to the API!**.

Since the `ColorConverter` doesn't have any member variables, only a single instance needs to be instantiated. Theses changes rename the class from `ColorConverter` to `ColorConverterClass`, and creates a global `ColorConverterClass` instance called `ColorConverter`. Sketches can then use the global instance.